### PR TITLE
Prevent undefined values for currentUI

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -743,7 +743,7 @@ function normalizeLocation(location) {
  */
 function toggleUI(currentUI, location) {
   var pathnameWithoutCF,
-      targetUI = (currentUI === UI_MAP_TOUCH) ? UI_MAP_CLASSIC : UI_MAP_TOUCH,
+      targetUI = (typeof currentUI === 'undefined' || currentUI === UI_MAP_TOUCH) ? UI_MAP_CLASSIC : UI_MAP_TOUCH,
       targetText,
       currentText,
       useHash;


### PR DESCRIPTION
Initial params passed to toggleUI are null when already on AEM with TouchUI set and wanting to switch back to ClassicUI with the toggle button, but that fails without this check